### PR TITLE
Fix: Issue of masonry layout height conflicting with bsf doc blog page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Build documentation website with live search functionality. This plugin provides
 
 ## Changelog ##
 
+### Version 1.0.5 ###
+- Fix: Issue of masonry layout height conflicting with bsf doc blog page.
+
 ### Version 1.0.4 ###
 - Improvement: Load scripts only on pages where shortcode is used.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **Contributors:** [brainstormforce](https://profiles.wordpress.org/brainstormforce)  
 **Tags:** docs, wpdocs, documentation, wpdocs, documentation  
 **Requires at least:** 3.0    
-**Tested up to:** 5.6  
-**Stable tag:** 1.0.4  
+**Tested up to:** 5.7  
+**Stable tag:** 1.0.5  
 
 BSF Docs allows you to create documentation website within minute with ajax search.
 

--- a/assets/js/searchbox-script.js
+++ b/assets/js/searchbox-script.js
@@ -2,6 +2,8 @@
 
 jQuery(document).ready(function() {
 
+	jQuery( '.search.blog-masonry #main > div, .blog.blog-masonry #main > div, .archive.blog-masonry #main > div' ).css({height: ''})
+
 	var ajax_url = bsf_ajax_url.url + '?action=bsf_load_search_results&query=';
 
 	jQuery('#bsf-live-search #bsf-sq').liveSearch({

--- a/bsf-docs.php
+++ b/bsf-docs.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://brainstormforce.com/
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
- * Version: 1.0.4
+ * Version: 1.0.5
  * Description: Easily build documentation website with AJAX based live search functionality. This plugin provides shortcodes to display category list & live search input box.
  * Text Domain: bsf-docs
  *

--- a/classes/class-bsf-doc-loader.php
+++ b/classes/class-bsf-doc-loader.php
@@ -272,7 +272,7 @@ if ( ! class_exists( 'Bsf_Doc_Loader' ) ) {
 
 			$file = dirname( dirname( __FILE__ ) );
 
-			define( 'BSF_DOCS_VERSION', '1.0.4' );
+			define( 'BSF_DOCS_VERSION', '1.0.5' );
 			define( 'BSF_DOCS_DIR_NAME', plugin_basename( $file ) );
 			define( 'BSF_DOCS_BASE_FILE', trailingslashit( $file ) . BSF_DOCS_DIR_NAME . '.php' );
 			define( 'BSF_DOCS_BASE_DIR', plugin_dir_path( BSF_DOCS_BASE_FILE ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -788,9 +788,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -806,9 +806,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -829,9 +829,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -1535,12 +1535,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -1762,9 +1762,9 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
     "split-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp_docs",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp_docs",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,9 @@ Build documentation website with live search functionality. This plugin provides
 
 == Changelog ==
 
+= Version 1.0.5 =
+- Fix: Issue of masonry layout height conflicting with bsf doc blog page.
+
 = Version 1.0.4 =
 - Improvement: Load scripts only on pages where shortcode is used.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: brainstormforce
 Tags: docs, wpdocs, documentation, wpdocs, documentation
 Requires at least: 3.0  
-Tested up to: 5.6
-Stable tag: 1.0.4
+Tested up to: 5.7
+Stable tag: 1.0.5
 
 BSF Docs allows you to create documentation website within minute with ajax search.
 


### PR DESCRIPTION
Reported on -
 - https://wordpress.org/support/topic/doesnt-play-well-with-astra-masonary-view/

Screenshot -
 - https://share.getcloudapp.com/yAu6QjEY

Step to reproduce -
- Install BSF doc.
- Add doc and add any categories to the doc.
- Go to Customizer > Blog / Archive > Grid layout > Select 3 Columns and Masonry Layout and visit the blog archive page.
- See here - https://share.getcloudapp.com/8Luk1Qzz